### PR TITLE
fixed delete phrase bug where phrase would remain in the input

### DIFF
--- a/src/sidebar/CanvasItem.js
+++ b/src/sidebar/CanvasItem.js
@@ -17,6 +17,11 @@ export function CanvasItem({
 }) {
 	const [inputPhrase, setInputPhrase] = useState(subPhrase ? subPhrase : '');
 
+	const handleDeletePhrase = (index) => {
+		addSubPhrase(index, null);
+		setInputPhrase('');
+	};
+
 	return (
 		<li
 			{...restProps}
@@ -84,7 +89,7 @@ export function CanvasItem({
 					<button type="button" onClick={() => addSubPhrase(index, inputPhrase)}>
 						Save
 					</button>
-					<button type="button" onClick={() => addSubPhrase(index, null)}>
+					<button type="button" onClick={() => handleDeletePhrase(index)}>
 						Delete phrase
 					</button>
 					<textarea defaultValue={JSON.stringify(userSettings, null, 2)} />


### PR DESCRIPTION
I found a bug where when you add a phrase per layer and hit "Delete phrase" it would not clear the value and it would just remain there making it unclear as to what phrase is affecting the layer

### The bug
![with-bug](https://user-images.githubusercontent.com/1266923/103718770-ae16c900-501b-11eb-8a2b-2e5e4be47be3.gif)

### Fixed
![without-bug](https://user-images.githubusercontent.com/1266923/103718655-61cb8900-501b-11eb-9297-63ff045356fa.gif)
