### PR TITLE
Rename Sidebar -> EditorSidebar

### DIFF
--- a/src/Editor.js
+++ b/src/Editor.js
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 
 import { Canvas } from './Canvas';
-import { Sidebar } from './Sidebar';
+import { EditorSidebar } from './EditorSidebar';
 import { getConfig } from './generateConfig';
 
 export function Editor() {
@@ -32,7 +32,7 @@ export function Editor() {
 			}}
 		>
 			<Canvas canvas={canvas} />
-			<Sidebar
+			<EditorSidebar
 				changePhrase={changePhrase}
 				phrase={phrase}
 				canvas={canvas}

--- a/src/EditorSidebar.js
+++ b/src/EditorSidebar.js
@@ -4,10 +4,10 @@ import { List, arrayMove } from 'react-movable';
 
 import * as layers from './layer';
 import { getConfig } from './generateConfig';
-import { LayerSelector, CanvasList, CanvasItem } from './sidebar/';
+import { LayerSelector, CanvasList, CanvasItem } from './sidebar';
 import { Phrase } from './Phrase';
 
-export function Sidebar({ changePhrase, phrase, canvas, setCanvas, regenCanvas }) {
+export function EditorSidebar({ changePhrase, phrase, canvas, setCanvas, regenCanvas }) {
 	const addLayer = (layer) => {
 		layer.userSettings = getConfig(layer.layerSettings, phrase);
 		layer.subPhrase = null;


### PR DESCRIPTION
With the navigation being in an `aside` this could be confusing. Moving it to`EditorSidebar` for now. Might be renamed to `LayerEditor` or `EditorProperties` in the future.